### PR TITLE
Improve NOTAM dashboard summaries and filters

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -36,6 +36,7 @@ export default function App() {
   const [filters, setFilters] = useState<Filters>(DEFAULT_FILTERS);
   const [favorites, setFavorites] = useState<string[]>(() => loadFavorites());
   const [highlightedNotamId, setHighlightedNotamId] = useState<string | null>(null);
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
   useEffect(() => {
     saveFavorites(favorites);
@@ -134,21 +135,49 @@ export default function App() {
       setShowGlobalLoading(true);
       return;
     }
+    if (typeof window === 'undefined') {
+      setShowGlobalLoading(false);
+      return;
+    }
     const timeout = window.setTimeout(() => setShowGlobalLoading(false), 600);
     return () => window.clearTimeout(timeout);
   }, [globalLoading]);
   const globalError = notamsError || airportsError;
+
+  useEffect(() => {
+    if (!globalLoading && !globalError) {
+      setLastUpdatedAt(new Date());
+    }
+  }, [globalLoading, globalError, notams]);
+
+  const lastUpdatedLabel = useMemo(() => {
+    if (!lastUpdatedAt) return null;
+    return lastUpdatedAt.toLocaleString('es-MX', {
+      timeZone: 'UTC',
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  }, [lastUpdatedAt]);
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 text-slate-100">
       <TopBar currentView={view} onViewChange={setView} onRefresh={refetchNotams} />
       <main className="mx-auto max-w-7xl space-y-8 px-6 py-12">
         <div className="min-h-[1.5rem]">
-          {showGlobalLoading && (
+          {showGlobalLoading ? (
             <div className="flex items-center gap-2 text-sm text-slate-400" role="status" aria-live="polite">
               <span className="h-2 w-2 animate-pulse rounded-full bg-sky-400" aria-hidden="true" />
               Cargando datos…
             </div>
+          ) : lastUpdatedLabel ? (
+            <p className="text-xs text-slate-400">Última actualización: {lastUpdatedLabel} UTC</p>
+          ) : (
+            <p className="text-xs text-slate-500">Datos listos.</p>
           )}
         </div>
         {globalError && (

--- a/frontend/src/components/FiltersBar.tsx
+++ b/frontend/src/components/FiltersBar.tsx
@@ -79,62 +79,77 @@ export function FiltersBar({ filters, onChange, catalogs, onClear, stationSugges
                   ? 'bg-sky-500 text-white shadow shadow-sky-500/40'
                   : 'text-slate-200 hover:bg-slate-800',
               )}
+              aria-pressed={filters.mode === option.value}
             >
               {option.label}
             </button>
           ))}
         </div>
         {filters.mode === 'RELATIVE' && (
-          <div className="flex flex-wrap items-center gap-2">
-            {RELATIVE_HOURS_OPTIONS.map((option) => (
-              <button
-                key={option}
-                type="button"
-                onClick={() => onChange({ ...filters, hours: option })}
-                className={clsx(
-                  'rounded-lg border px-3 py-2 text-xs font-semibold uppercase tracking-wide transition-colors',
-                  filters.hours === option
-                    ? 'border-sky-400 bg-sky-500/20 text-sky-200'
-                    : 'border-slate-700 bg-slate-900 hover:border-slate-500',
-                )}
-              >
-                {option}h
-              </button>
-            ))}
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              {RELATIVE_HOURS_OPTIONS.map((option) => (
+                <button
+                  key={option}
+                  type="button"
+                  onClick={() => onChange({ ...filters, hours: option })}
+                  className={clsx(
+                    'rounded-lg border px-3 py-2 text-xs font-semibold uppercase tracking-wide transition-colors',
+                    filters.hours === option
+                      ? 'border-sky-400 bg-sky-500/20 text-sky-200'
+                      : 'border-slate-700 bg-slate-900 hover:border-slate-500',
+                  )}
+                  aria-pressed={filters.hours === option}
+                >
+                  {option}h
+                </button>
+              ))}
+            </div>
+            <p className="text-[11px] text-slate-400">
+              Mostrando NOTAM publicados en las últimas {filters.hours ?? DEFAULT_FILTERS.hours} horas (UTC).
+            </p>
           </div>
         )}
         {filters.mode === 'ABSOLUTE' && (
-          <div className="flex flex-wrap gap-3 text-xs">
-            <label className="flex flex-col">
-              <span className="font-semibold uppercase tracking-wide text-slate-400">Desde (UTC)</span>
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
-                value={filters.from ? filters.from.slice(0, 16) : ''}
-                onChange={(event) => {
-                  const iso = event.target.value ? new Date(event.target.value).toISOString() : null;
-                  onChange({ ...filters, from: iso, mode: 'ABSOLUTE' });
-                }}
-              />
-            </label>
-            <label className="flex flex-col">
-              <span className="font-semibold uppercase tracking-wide text-slate-400">Hasta (UTC)</span>
-              <input
-                type="datetime-local"
-                className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
-                value={filters.to ? filters.to.slice(0, 16) : ''}
-                onChange={(event) => {
-                  const iso = event.target.value ? new Date(event.target.value).toISOString() : null;
-                  onChange({ ...filters, to: iso, mode: 'ABSOLUTE' });
-                }}
-              />
-            </label>
+          <div className="flex flex-col gap-2 text-xs">
+            <div className="flex flex-wrap gap-3">
+              <label className="flex flex-col">
+                <span className="font-semibold uppercase tracking-wide text-slate-400">Desde (UTC)</span>
+                <input
+                  type="datetime-local"
+                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                  value={filters.from ? filters.from.slice(0, 16) : ''}
+                  onChange={(event) => {
+                    const iso = event.target.value ? new Date(event.target.value).toISOString() : null;
+                    onChange({ ...filters, from: iso, mode: 'ABSOLUTE' });
+                  }}
+                />
+              </label>
+              <label className="flex flex-col">
+                <span className="font-semibold uppercase tracking-wide text-slate-400">Hasta (UTC)</span>
+                <input
+                  type="datetime-local"
+                  className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                  value={filters.to ? filters.to.slice(0, 16) : ''}
+                  onChange={(event) => {
+                    const iso = event.target.value ? new Date(event.target.value).toISOString() : null;
+                    onChange({ ...filters, to: iso, mode: 'ABSOLUTE' });
+                  }}
+                />
+              </label>
+            </div>
+            <p className="text-[11px] text-slate-400">
+              Selecciona un rango exacto en hora local; lo convertimos automáticamente a UTC para la consulta.
+            </p>
           </div>
         )}
         {filters.mode === 'DAILY' && (
-          <p className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2 text-xs">
-            {`${formatUtcLabel(dailyRange.start.toISOString())} → ${formatUtcLabel(dailyRange.end.toISOString())}`}
-          </p>
+          <div className="space-y-1 text-xs">
+            <p className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2">
+              {`${formatUtcLabel(dailyRange.start.toISOString())} → ${formatUtcLabel(dailyRange.end.toISOString())}`}
+            </p>
+            <p className="text-[11px] text-slate-400">Mostrando únicamente los NOTAM activos durante el día UTC actual.</p>
+          </div>
         )}
       </div>
 

--- a/frontend/src/components/NotamCard.tsx
+++ b/frontend/src/components/NotamCard.tsx
@@ -3,6 +3,8 @@ import clsx from 'clsx';
 import SeverityBadge from './SeverityBadge';
 import CategoryChip from './CategoryChip';
 import type { Notam } from '../types/notam';
+import { formatUtcRangeWithSuffix } from '../utils/datetime';
+import { extractNotamSummary } from '../utils/notamText';
 
 interface NotamCardProps {
   notam: Notam;
@@ -14,35 +16,6 @@ interface NotamCardProps {
   onViewOnMap?: (notam: Notam) => void;
   onSeeAllFromStation?: (icao: string) => void;
   expanded?: boolean;
-}
-
-function formatUtcRange(start?: string | null, end?: string | null) {
-  const format = (value?: string | null) => {
-    if (!value) return '—';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return '—';
-    return `${date.toLocaleString('es-MX', {
-      timeZone: 'UTC',
-      hour12: false,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })} UTC`;
-  };
-
-  return `${format(start)} → ${format(end)}`;
-}
-
-function extractSummary(notam: Notam) {
-  if (notam.condition) return notam.condition;
-  if (notam.subject) return notam.subject;
-  const match = /E\)([\s\S]*)/i.exec(notam.text ?? '');
-  if (match && match[1]) {
-    return match[1].trim();
-  }
-  return notam.text ?? '';
 }
 
 function computeTimeline(notam: Notam) {
@@ -69,7 +42,7 @@ export function NotamCard({
   expanded = false,
 }: NotamCardProps) {
   const [showFull, setShowFull] = useState(expanded);
-  const summary = extractSummary(notam);
+  const summary = extractNotamSummary(notam);
   const timeline = computeTimeline(notam);
 
   return (
@@ -87,7 +60,9 @@ export function NotamCard({
 
       <div className="space-y-3 text-sm text-slate-200">
         <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Vigencia</p>
-        <p className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-100">{formatUtcRange(notam.start_at, notam.end_at)}</p>
+        <p className="rounded-lg border border-slate-800 bg-slate-900/70 px-3 py-2 text-sm text-slate-100">
+          {formatUtcRangeWithSuffix(notam.start_at, notam.end_at)}
+        </p>
         {summary && (
           <div className="space-y-2">
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Resumen</p>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import 'mapbox-gl/dist/mapbox-gl.css';
 import App from './App';
 import './index.css';
 

--- a/frontend/src/types/recharts-module.ts
+++ b/frontend/src/types/recharts-module.ts
@@ -1,0 +1,1 @@
+declare module 'recharts';

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -1,0 +1,28 @@
+export function formatUtc(value?: string | null, fallback = '—') {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return date.toLocaleString('es-MX', {
+    timeZone: 'UTC',
+    hour12: false,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export function formatUtcRange(start?: string | null, end?: string | null, fallback = '—') {
+  return `${formatUtc(start, fallback)} → ${formatUtc(end, fallback)}`;
+}
+
+export function formatUtcWithSuffix(value?: string | null, fallback = '—') {
+  const formatted = formatUtc(value, fallback);
+  if (formatted === fallback) return fallback;
+  return `${formatted} UTC`;
+}
+
+export function formatUtcRangeWithSuffix(start?: string | null, end?: string | null, fallback = '—') {
+  return `${formatUtcWithSuffix(start, fallback)} → ${formatUtcWithSuffix(end, fallback)}`;
+}

--- a/frontend/src/utils/notamText.ts
+++ b/frontend/src/utils/notamText.ts
@@ -1,0 +1,22 @@
+import type { Notam } from '../types/notam';
+
+function cleanText(value?: string | null) {
+  if (!value) return '';
+  return value.replace(/\s+/g, ' ').replace(/\s+([.,;:])/g, '$1').trim();
+}
+
+export function extractNotamSummary(notam: Pick<Notam, 'condition' | 'subject' | 'text'>) {
+  if (notam.condition) return cleanText(notam.condition);
+  if (notam.subject) return cleanText(notam.subject);
+  const match = /E\)([\s\S]*)/i.exec(notam.text ?? '');
+  if (match && match[1]) {
+    return cleanText(match[1]);
+  }
+  return cleanText(notam.text ?? '');
+}
+
+export function getNotamSummarySnippet(notam: Pick<Notam, 'condition' | 'subject' | 'text'>, maxLength = 200) {
+  const summary = extractNotamSummary(notam);
+  if (summary.length <= maxLength) return summary;
+  return `${summary.slice(0, maxLength).trimEnd()}…`;
+}

--- a/frontend/src/views/Favorites.tsx
+++ b/frontend/src/views/Favorites.tsx
@@ -6,6 +6,8 @@ import type { Airport, Catalogs, Notam } from '../types/notam';
 import type { StationSuggestion } from '../components/StationSearch';
 import StationSearch from '../components/StationSearch';
 import SeverityBadge from '../components/SeverityBadge';
+import { formatUtcRangeWithSuffix } from '../utils/datetime';
+import { getNotamSummarySnippet } from '../utils/notamText';
 import { mapSeverity } from '../utils/severity';
 
 interface FavoritesViewProps {
@@ -25,24 +27,6 @@ interface FavoritesViewProps {
 }
 
 const ITEMS_PER_PAGE = 6;
-
-function formatUtcRange(start?: string | null, end?: string | null) {
-  const format = (value?: string | null) => {
-    if (!value) return '—';
-    const date = new Date(value);
-    if (Number.isNaN(date.getTime())) return '—';
-    return `${date.toLocaleString('es-MX', {
-      timeZone: 'UTC',
-      hour12: false,
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      hour: '2-digit',
-      minute: '2-digit',
-    })} UTC`;
-  };
-  return `${format(start)} → ${format(end)}`;
-}
 
 function getTimeline(notams: Notam[]) {
   const entries = notams
@@ -307,7 +291,7 @@ export function FavoritesView({
                             left: `${item.left}%`,
                             width: `${item.width}%`,
                           }}
-                          title={`${item.notam.number ?? item.notam.id} • ${formatUtcRange(item.notam.start_at, item.notam.end_at)}`}
+                          title={`${item.notam.number ?? item.notam.id} • ${formatUtcRangeWithSuffix(item.notam.start_at, item.notam.end_at)}`}
                         >
                           <span className="sr-only">{item.notam.number}</span>
                         </div>
@@ -329,7 +313,12 @@ export function FavoritesView({
                             <div>
                               <p className="text-sm font-semibold text-slate-100">{notam.number ?? notam.id}</p>
                               <p className="text-xs text-slate-400">{category?.label ?? 'Sin categoría'}</p>
-                              <p className="text-xs text-slate-400">{formatUtcRange(notam.start_at, notam.end_at)}</p>
+                              <p className="text-xs text-slate-400">
+                                {formatUtcRangeWithSuffix(notam.start_at, notam.end_at)}
+                              </p>
+                              <p className="mt-1 text-xs text-slate-300">
+                                {getNotamSummarySnippet(notam, 140) || 'Sin descripción disponible'}
+                              </p>
                             </div>
                             <div className="flex flex-col items-end gap-2">
                               <SeverityBadge value={notam.severity} />

--- a/frontend/src/views/Globe.tsx
+++ b/frontend/src/views/Globe.tsx
@@ -7,6 +7,7 @@ import type { Airport, Catalogs, Notam } from '../types/notam';
 import type { StationSuggestion } from '../components/StationSearch';
 import NotamCard from '../components/NotamCard';
 import SeverityBadge from '../components/SeverityBadge';
+import { getNotamSummarySnippet } from '../utils/notamText';
 import { mapSeverity } from '../utils/severity';
 
 interface GlobeViewProps {
@@ -43,6 +44,9 @@ interface MarkerInfo {
   longitude: number;
   count: number;
   maxSeverity: number;
+  previewNotamId: string | null;
+  previewSummary: string | null;
+  previewStartAt: number | null;
 }
 
 export function GlobeView({
@@ -83,8 +87,19 @@ export function GlobeView({
       if (latitude == null || longitude == null) continue;
       const existing = byIcao.get(notam.icao);
       const severity = notam.severity ?? 0;
+      const summary = getNotamSummarySnippet(notam, 160);
+      const startAt = notam.start_at ? new Date(notam.start_at).getTime() : null;
       if (existing) {
         existing.count += 1;
+        if (
+          severity > existing.maxSeverity ||
+          (severity === existing.maxSeverity && (startAt ?? -Infinity) > (existing.previewStartAt ?? -Infinity)) ||
+          existing.previewNotamId === null
+        ) {
+          existing.previewNotamId = notam.id;
+          existing.previewSummary = summary;
+          existing.previewStartAt = startAt;
+        }
         existing.maxSeverity = Math.max(existing.maxSeverity, severity);
       } else {
         byIcao.set(notam.icao, {
@@ -93,6 +108,9 @@ export function GlobeView({
           longitude,
           count: 1,
           maxSeverity: severity,
+          previewNotamId: notam.id,
+          previewSummary: summary,
+          previewStartAt: startAt,
         });
       }
     }
@@ -166,6 +184,7 @@ export function GlobeView({
                             onSelectedNotamChange?.(id);
                           }
                         }}
+                        title={marker.previewSummary ?? undefined}
                       >
                         <span className="rounded-full bg-slate-900/80 px-2 py-1 shadow-lg shadow-slate-950/50">
                           {marker.icao}
@@ -230,12 +249,19 @@ export function GlobeView({
 
           <div className="grid gap-4 sm:grid-cols-2">
             {filteredNotams.slice(0, 6).map((item) => (
-              <div key={item.id} className="rounded-xl border border-slate-800 bg-slate-950/70 p-4">
+              <div
+                key={item.id}
+                className="rounded-xl border border-slate-800 bg-slate-950/70 p-4"
+                title={getNotamSummarySnippet(item, 160)}
+              >
                 <p className="text-sm font-semibold text-slate-100">{item.number ?? item.id}</p>
                 <p className="text-xs text-slate-400">{item.icao}</p>
                 <div className="mt-2">
                   <SeverityBadge value={item.severity} />
                 </div>
+                <p className="mt-2 text-xs text-slate-300">
+                  {getNotamSummarySnippet(item, 120) || 'Sin descripción disponible'}
+                </p>
                 <button
                   type="button"
                   className="mt-3 text-xs font-semibold uppercase tracking-wide text-sky-300 hover:text-sky-200"

--- a/frontend/src/views/List.tsx
+++ b/frontend/src/views/List.tsx
@@ -5,6 +5,8 @@ import type { Airport, Catalogs, Notam } from '../types/notam';
 import type { StationSuggestion } from '../components/StationSearch';
 import CategoryChip from '../components/CategoryChip';
 import SeverityBadge from '../components/SeverityBadge';
+import { formatUtcRangeWithSuffix } from '../utils/datetime';
+import { extractNotamSummary, getNotamSummarySnippet } from '../utils/notamText';
 import { mapSeverity } from '../utils/severity';
 
 interface ListViewProps {
@@ -22,30 +24,10 @@ interface ListViewProps {
 
 type SortKey = 'severity' | 'validity';
 
-function formatUtc(value?: string | null) {
-  if (!value) return '—';
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '—';
-  return `${date.toLocaleString('es-MX', {
-    timeZone: 'UTC',
-    hour12: false,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-  })} UTC`;
-}
-
 function buildTooltip(notam: Notam) {
-  const summary = notam.condition || notam.subject || extractE(notam.text);
+  const summary = extractNotamSummary(notam);
   const qLine = notam.q_line ? `\nQ-line: ${notam.q_line}` : '';
   return `${summary ?? ''}${qLine}`.trim();
-}
-
-function extractE(text: string) {
-  const match = /E\)([\s\S]*)/i.exec(text ?? '');
-  return match && match[1] ? match[1].trim() : text;
 }
 
 export function ListView({
@@ -129,6 +111,7 @@ export function ListView({
                 <th className="px-4 py-3 text-left">NOTAM</th>
                 <th className="px-4 py-3 text-left">Estación</th>
                 <th className="px-4 py-3 text-left">Categoría</th>
+                <th className="px-4 py-3 text-left">Resumen</th>
                 <th className="px-4 py-3 text-left">
                   <button
                     type="button"
@@ -169,8 +152,11 @@ export function ListView({
                     <td className="px-4 py-3">
                       {category ? <CategoryChip label={category.label} color={category.color} /> : <span className="text-xs text-slate-400">Sin categoría</span>}
                     </td>
+                    <td className="px-4 py-3 text-xs text-slate-300" title={tooltip}>
+                      {getNotamSummarySnippet(notam, 160) || 'Sin descripción disponible'}
+                    </td>
                     <td className="px-4 py-3 text-sm text-slate-200">
-                      {`${formatUtc(notam.start_at)} → ${formatUtc(notam.end_at)}`}
+                      {formatUtcRangeWithSuffix(notam.start_at, notam.end_at)}
                     </td>
                     <td className="px-4 py-3">
                       <SeverityBadge value={notam.severity} className="text-xs" />


### PR DESCRIPTION
## Summary
- add shared helpers to extract NOTAM summaries and format UTC ranges, surfacing summaries across globe, list, cards, and favorites views
- improve the global loading indicator with a last-updated timestamp and import Mapbox styles so the map renders correctly
- refine the time filter controls with contextual help text for each mode and provide a module declaration for Recharts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9a6b509e4832bbcac0000ad4570b3