### PR TITLE
Fix NOTAM category filtering and stabilize map interactions

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import type { Airport, Notam, Catalogs } from '../types/notam';
 
 export type NotamFilters = {
-  category?: string;
+  cat?: string;
   hours?: number;
   from?: string;
   to?: string;

--- a/frontend/src/components/StationSearch.tsx
+++ b/frontend/src/components/StationSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 export interface StationSuggestion {
@@ -28,17 +28,28 @@ export function StationSearch({
 }: StationSearchProps) {
   const [inputValue, setInputValue] = useState(value);
   const [open, setOpen] = useState(false);
+  const debouncedCallbackRef = useRef(onDebouncedChange);
+  const lastEmittedRef = useRef(value.trim());
+
+  useEffect(() => {
+    debouncedCallbackRef.current = onDebouncedChange;
+  }, [onDebouncedChange]);
 
   useEffect(() => {
     setInputValue(value);
   }, [value]);
 
   useEffect(() => {
-    const handle = setTimeout(() => {
-      onDebouncedChange(inputValue.trim());
+    const trimmed = inputValue.trim();
+    if (lastEmittedRef.current === trimmed) {
+      return undefined;
+    }
+    const handle = window.setTimeout(() => {
+      lastEmittedRef.current = trimmed;
+      debouncedCallbackRef.current(trimmed);
     }, debounceMs);
-    return () => clearTimeout(handle);
-  }, [inputValue, debounceMs, onDebouncedChange]);
+    return () => window.clearTimeout(handle);
+  }, [inputValue, debounceMs]);
 
   const filteredSuggestions = useMemo(() => {
     if (!inputValue) return suggestions.slice(0, 8);
@@ -82,7 +93,9 @@ export function StationSearch({
                   event.preventDefault();
                   setInputValue(item.icao);
                   onImmediateChange?.(item.icao);
-                  onDebouncedChange(item.icao);
+                  const trimmed = item.icao.trim();
+                  lastEmittedRef.current = trimmed;
+                  debouncedCallbackRef.current(trimmed);
                   setOpen(false);
                 }}
               >

--- a/frontend/src/hooks/useNotams.ts
+++ b/frontend/src/hooks/useNotams.ts
@@ -37,7 +37,7 @@ function buildQuery(filters: Filters, applyStationFilter: boolean): [NotamFilter
   }
 
   if (filters.category && filters.category !== 'all') {
-    query.category = filters.category;
+    query.cat = filters.category;
   }
 
   const trimmed = filters.stationQuery?.trim().toUpperCase() ?? '';

--- a/frontend/src/views/Globe.tsx
+++ b/frontend/src/views/Globe.tsx
@@ -117,7 +117,13 @@ export function GlobeView({
     return Array.from(byIcao.values());
   }, [notams, airports]);
 
-  const selectedNotam = useMemo(() => filteredNotams.find((item) => item.id === selectedNotamId) ?? null, [filteredNotams, selectedNotamId]);
+  const selectedNotam = useMemo(() => {
+    const inFiltered = filteredNotams.find((item) => item.id === selectedNotamId);
+    if (inFiltered) {
+      return inFiltered;
+    }
+    return notams.find((item) => item.id === selectedNotamId) ?? null;
+  }, [filteredNotams, notams, selectedNotamId]);
 
   const categories = useMemo(() => catalogs?.categories ?? [], [catalogs]);
   const categoryIndex = useMemo(() => new Map(categories.map((category) => [category.id, category])), [categories]);


### PR DESCRIPTION
## Summary
- send the category filter using the API's `cat` parameter so the dropdown applies server-side filtering
- stop the station search debounce loop from firing continuously and preserve the selected NOTAM when the marker falls outside the filtered subset

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9ab09f634832ba5ee14e85f3db9b1