### PR TITLE
Refine header styling and favorites layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NOTAM Operational Dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body class="bg-slate-950 text-slate-100">
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -167,7 +167,7 @@ export default function App() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 text-slate-100">
       <TopBar currentView={view} onViewChange={setView} onRefresh={refetchNotams} />
-      <main className="mx-auto max-w-7xl space-y-8 px-6 py-12">
+      <main className="mx-auto max-w-[110rem] space-y-8 px-6 py-12 lg:px-10">
         <div className="min-h-[1.5rem]">
           {showGlobalLoading ? (
             <div className="flex items-center gap-2 text-sm text-slate-400" role="status" aria-live="polite">

--- a/frontend/src/components/StationSearch.tsx
+++ b/frontend/src/components/StationSearch.tsx
@@ -63,7 +63,7 @@ export function StationSearch({
 
   return (
     <div className="relative">
-      <label className="flex flex-col text-xs font-semibold uppercase tracking-wide text-slate-400">
+      <label className="flex flex-col text-[11px] font-semibold uppercase tracking-[0.28em] text-slate-400">
         Estación
         <input
           value={inputValue}
@@ -77,7 +77,7 @@ export function StationSearch({
             setTimeout(() => setOpen(false), 150);
           }}
           placeholder={placeholder}
-          className="mt-1 w-full rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
+          className="mt-1 w-full rounded-full border border-slate-700/80 bg-slate-900/80 px-4 py-1.5 text-sm text-slate-100 placeholder:text-slate-500 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500"
         />
       </label>
       {open && filteredSuggestions.length > 0 && (

--- a/frontend/src/components/TopBar.tsx
+++ b/frontend/src/components/TopBar.tsx
@@ -24,36 +24,36 @@ export function TopBar({ currentView, onViewChange, rightSlot, onRefresh }: TopB
   const clock = useUtcClock();
 
   return (
-    <header className="sticky top-0 z-30 border-b border-slate-800 bg-slate-950/90 backdrop-blur">
-      <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-4">
-        <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+    <header className="sticky top-0 z-30 border-b border-slate-900/70 bg-slate-950/80 backdrop-blur-sm">
+      <div className="mx-auto flex max-w-[110rem] flex-col gap-3 px-5 py-3">
+        <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div className="flex flex-1 items-center justify-start">
             <a href="/" className="inline-flex items-center" aria-label="Inicio SENEAM">
               <img
                 src={logo1x}
                 srcSet={`${logo1x} 260w, ${logo2x} 520w`}
-                sizes="(max-width: 768px) 180px, 260px"
+                sizes="(max-width: 768px) 180px, 240px"
                 alt="SENEAM"
-                className="h-auto max-h-16 w-auto"
+                className="h-auto max-h-12 w-auto"
                 loading="lazy"
                 decoding="async"
               />
             </a>
           </div>
-          <div className="flex flex-1 flex-col items-center gap-2 text-center md:flex-row md:justify-center">
-            <p className="text-base font-semibold uppercase tracking-[0.18em] text-slate-200 sm:text-lg">
+          <div className="flex flex-1 flex-col items-center gap-1 text-center md:flex-row md:justify-center md:gap-3">
+            <p className="whitespace-nowrap text-lg font-semibold uppercase tracking-[0.12em] text-slate-100 font-['Montserrat',_Helvetica,_Arial,_sans-serif]">
               NOTAM Operational Dashboard
             </p>
-            <span className="rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-slate-300">
+            <span className="whitespace-nowrap rounded-full border border-slate-700/70 bg-slate-900/70 px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-[0.32em] text-slate-300">
               {clock}
             </span>
           </div>
-          <div className="flex flex-1 items-center justify-end gap-3">
+          <div className="flex flex-1 items-center justify-end gap-2">
             {onRefresh && (
               <button
                 type="button"
                 onClick={onRefresh}
-                className="rounded-full border border-sky-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-sky-200 transition hover:bg-slate-900"
+                className="rounded-full border border-sky-500/70 px-4 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-200 transition hover:bg-slate-900/70"
               >
                 Refrescar
               </button>
@@ -62,16 +62,16 @@ export function TopBar({ currentView, onViewChange, rightSlot, onRefresh }: TopB
           </div>
         </div>
         <nav className="flex justify-center">
-          <div className="inline-flex rounded-full border border-slate-700 bg-slate-900/80 p-1 shadow-inner shadow-slate-900/40">
+          <div className="inline-flex rounded-full border border-slate-700/70 bg-slate-900/70 p-0.5 shadow-inner shadow-slate-900/30">
             {VIEWS.map((option) => (
               <button
                 key={option.value}
                 type="button"
                 className={clsx(
-                  'rounded-full px-4 py-1 text-sm font-semibold uppercase tracking-wide transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950',
+                  'rounded-full px-3.5 py-1 text-xs font-semibold uppercase tracking-wide transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-2 focus:ring-offset-slate-950',
                   currentView === option.value
                     ? 'bg-sky-500 text-white shadow shadow-sky-500/40'
-                    : 'text-slate-300 hover:bg-slate-800',
+                    : 'text-slate-300 hover:bg-slate-800/70',
                 )}
                 onClick={() => onViewChange(option.value)}
               >

--- a/frontend/src/views/Favorites.tsx
+++ b/frontend/src/views/Favorites.tsx
@@ -26,7 +26,7 @@ interface FavoritesViewProps {
   onRetry?: () => void;
 }
 
-const ITEMS_PER_PAGE = 6;
+const ITEMS_PER_PAGE = 5;
 
 function getTimeline(notams: Notam[]) {
   const entries = notams
@@ -115,8 +115,8 @@ export function FavoritesView({
       />
 
       <section className="space-y-4 rounded-2xl border border-slate-800 bg-slate-950/70 p-4">
-        <header className="flex flex-wrap items-center gap-4">
-          <div className="flex-1 min-w-[220px]">
+        <header className="flex flex-wrap items-center gap-3">
+          <div className="min-w-[240px] flex-1">
             <StationSearch
               value={newFavorite}
               onImmediateChange={setNewFavorite}
@@ -132,7 +132,7 @@ export function FavoritesView({
           </div>
           <button
             type="button"
-            className="rounded-full border border-sky-500 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-sky-200 transition hover:bg-slate-900"
+            className="rounded-full border border-sky-500/80 px-4 py-1.5 text-xs font-semibold uppercase tracking-wide text-sky-200 transition hover:bg-slate-900/70"
             onClick={() => {
               const trimmed = newFavorite.trim().toUpperCase();
               if (trimmed.length === 4 && !favorites.includes(trimmed)) {
@@ -203,7 +203,7 @@ export function FavoritesView({
           Agrega estaciones favoritas para ver su dashboard.
         </div>
       ) : (
-        <div className="grid gap-6 xl:grid-cols-2">
+        <div className="grid gap-4 lg:grid-cols-5">
           {paginatedFavorites.map((icao) => {
             const stationNotams = dataByStation.get(icao) ?? [];
             const airport = airportIndex.get(icao);
@@ -233,29 +233,42 @@ export function FavoritesView({
             const topNotams = [...stationNotams].sort((a, b) => (b.severity ?? 0) - (a.severity ?? 0)).slice(0, 3);
 
             return (
-              <section key={icao} className="space-y-4 rounded-3xl border border-slate-800 bg-slate-950/70 p-6 shadow-lg shadow-slate-950/30">
-                <header className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <h2 className="text-lg font-semibold text-slate-100">{icao}</h2>
-                    <p className="text-sm text-slate-400">{airport?.name ?? 'Aeródromo desconocido'}</p>
+              <section
+                key={icao}
+                className="flex min-w-0 flex-col gap-3 rounded-3xl border border-slate-800 bg-slate-950/70 p-4 shadow-lg shadow-slate-950/30"
+              >
+                <header className="flex flex-col gap-2">
+                  <div className="min-h-[3.75rem]">
+                    <h2 className="text-base font-semibold uppercase tracking-[0.18em] text-slate-100">{icao}</h2>
+                    <p
+                      className="text-[13px] text-slate-400"
+                      style={{
+                        display: '-webkit-box',
+                        WebkitLineClamp: 2,
+                        WebkitBoxOrient: 'vertical',
+                        overflow: 'hidden',
+                      }}
+                    >
+                      {airport?.name ?? 'Aeródromo desconocido'}
+                    </p>
                   </div>
-                  <div className="flex items-center gap-3 text-xs text-slate-200">
-                    <div className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2">
-                      <p className="font-semibold text-slate-100">{active}</p>
-                      <p className="text-[10px] uppercase tracking-wide text-slate-400">Activos</p>
+                  <div className="grid grid-cols-3 gap-2 text-center text-[11px] text-slate-200">
+                    <div className="rounded-2xl border border-slate-700 bg-slate-900/70 px-2 py-2">
+                      <p className="text-sm font-semibold text-slate-100">{active}</p>
+                      <p className="uppercase tracking-[0.24em] text-slate-400">Activos</p>
                     </div>
-                    <div className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2">
-                      <p className="font-semibold text-slate-100">{upcoming}</p>
-                      <p className="text-[10px] uppercase tracking-wide text-slate-400">Próximos</p>
+                    <div className="rounded-2xl border border-slate-700 bg-slate-900/70 px-2 py-2">
+                      <p className="text-sm font-semibold text-slate-100">{upcoming}</p>
+                      <p className="uppercase tracking-[0.24em] text-slate-400">Próximos</p>
                     </div>
-                    <div className="rounded-lg border border-slate-700 bg-slate-900/80 px-3 py-2">
-                      <p className="font-semibold text-slate-100">{upcoming24}</p>
-                      <p className="text-[10px] uppercase tracking-wide text-slate-400">Próx. 24h</p>
+                    <div className="rounded-2xl border border-slate-700 bg-slate-900/70 px-2 py-2">
+                      <p className="text-sm font-semibold text-slate-100">{upcoming24}</p>
+                      <p className="uppercase tracking-[0.24em] text-slate-400">Próx. 24h</p>
                     </div>
                   </div>
                 </header>
 
-                <div className="h-48 w-full rounded-2xl border border-slate-800 bg-slate-900/70 p-2">
+                <div className="h-40 w-full rounded-2xl border border-slate-800 bg-slate-900/70 p-2">
                   {barData.length === 0 ? (
                     <p className="flex h-full items-center justify-center text-xs text-slate-400">Sin datos de categorías</p>
                   ) : (
@@ -277,9 +290,9 @@ export function FavoritesView({
                   )}
                 </div>
 
-                <div className="space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Timeline</p>
-                  <div className="relative h-16 rounded-xl border border-slate-800 bg-slate-900/70">
+                <div className="space-y-1.5">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">Timeline</p>
+                  <div className="relative h-14 rounded-xl border border-slate-800 bg-slate-900/70">
                     {timeline.length === 0 ? (
                       <p className="flex h-full items-center justify-center text-xs text-slate-500">Sin vigencias programadas</p>
                     ) : (
@@ -300,31 +313,34 @@ export function FavoritesView({
                   </div>
                 </div>
 
-                <div className="space-y-2">
-                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Top 3 por severidad</p>
+                <div className="space-y-1.5">
+                  <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-slate-400">Top 3 por severidad</p>
                   {topNotams.length === 0 ? (
                     <p className="text-xs text-slate-500">Sin NOTAM en esta estación</p>
                   ) : (
-                    <ul className="space-y-2">
+                    <ul className="space-y-1.5">
                       {topNotams.map((notam) => {
                         const category = notam.category ? categoryIndex.get(notam.category) : null;
                         return (
-                          <li key={notam.id} className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-slate-800 bg-slate-900/70 px-3 py-2">
+                          <li
+                            key={notam.id}
+                            className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-900/70 px-3 py-2 sm:flex-row sm:items-center sm:justify-between"
+                          >
                             <div>
                               <p className="text-sm font-semibold text-slate-100">{notam.number ?? notam.id}</p>
                               <p className="text-xs text-slate-400">{category?.label ?? 'Sin categoría'}</p>
                               <p className="text-xs text-slate-400">
                                 {formatUtcRangeWithSuffix(notam.start_at, notam.end_at)}
                               </p>
-                              <p className="mt-1 text-xs text-slate-300">
+                              <p className="mt-1 text-[11px] text-slate-300">
                                 {getNotamSummarySnippet(notam, 140) || 'Sin descripción disponible'}
                               </p>
                             </div>
-                            <div className="flex flex-col items-end gap-2">
+                            <div className="flex flex-row items-center justify-end gap-2 sm:flex-col sm:items-end">
                               <SeverityBadge value={notam.severity} />
                               <button
                                 type="button"
-                                className="rounded-full border border-sky-500 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-200"
+                                className="rounded-full border border-sky-500/80 px-3 py-1 text-[11px] font-semibold uppercase tracking-wide text-sky-200 hover:bg-slate-900/70"
                                 onClick={() => onSelectStation(notam.icao)}
                               >
                                 Detalles


### PR DESCRIPTION
## Summary
- load the Montserrat font and restyle the top bar so the title, UTC clock, and logo sit in a slimmer header
- widen the main content area and slim down the station search field to better use horizontal space
- rework the favorites dashboard to show five stations per page with compact cards and updated metrics layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d9af084478832b8e488c78cd2fc123