### PR TITLE
Fix NOTAM station parsing

### DIFF
--- a/api/src/services/notamParser.ts
+++ b/api/src/services/notamParser.ts
@@ -1,7 +1,7 @@
 import { ParsedNotam, NotamStatus } from '../types';
 
 const Q_LINE_REGEX = /Q\)\s*([A-Z]{4})\/([A-Z]{5})\/([A-Z]{1,2})\/([A-Z]{1,4})\/([A-Z]{1,2})\/([0-9]{3})\/([0-9]{3})\/([0-9]{4}[NS][0-9]{5}[EW][0-9]{3})/;
-const SECTION_REGEX = /([A-G])\)\s*([^A-G\)]*)(?=\s+[A-G]\)|$)/g;
+const SECTION_REGEX = /([A-G])\)\s*([\s\S]*?)(?=\n\s*[A-G]\)|$)/g;
 const NUMBER_REGEX = /\(([A-Z]\d{4}\/\d{2})\s+NOTAM[NC]|NOTAM[NRC]\s*([A-Z]\d{4}\/\d{2})/;
 const ICAO_REGEX = /\b([A-Z]{4})\b/;
 

--- a/api/tests/notamParser.test.ts
+++ b/api/tests/notamParser.test.ts
@@ -27,4 +27,20 @@ describe('parseNotam', () => {
     expect(parsed.schedule).toBe('0100-1100');
     expect(parsed.status === 'UPCOMING' || parsed.status === 'ACTIVE' || parsed.status === 'EXPIRED').toBeTruthy();
   });
+
+  it('extracts ICAO from section A even when FIR is present', () => {
+    const raw = `(
+A1234/24 NOTAMN
+Q) MMFR/QXXXX/IV/NBO/A/000/999/1800N09900W005
+A) MMCN/MMFR FIR
+B) 2401010000
+C) 2401312359
+E) RWY CLOSED
+)`;
+
+    const parsed = parseNotam(raw);
+
+    expect(parsed.fir).toBe('MMFR');
+    expect(parsed.icao).toBe('MMCN');
+  });
 });


### PR DESCRIPTION
## Summary
- update the NOTAM parser to retain section A content even when it includes FIR details
- add a regression test to ensure ICAO codes are extracted from section A before falling back to the FIR

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9b73c61cc832bb79698bd594b8a11